### PR TITLE
Improvement of Pad Background Color

### DIFF
--- a/src/doodlepad/Pad.java
+++ b/src/doodlepad/Pad.java
@@ -1204,6 +1204,16 @@ public class Pad extends JFrame implements Iterable<Shape>
     public Pad(String title, int width, int height) {
         this(title, width, height, Color.WHITE);
     }
+
+    /**
+     * Simple Pad constructor taking only title and window dimensions
+     * @param width The width of the window
+     * @param height The height of the window
+     * @param background The default color of the background
+     */
+    public Pad(int width, int height, Color background) {
+        this("DoodlePad", width, height, background);
+    }
     
     /**
      * Simple Pad constructor taking only window dimensions
@@ -1342,6 +1352,16 @@ public class Pad extends JFrame implements Iterable<Shape>
         this.setBackground(gray, gray, gray);
     }
     
+    /**
+     * Set the background color by passing a Color object
+     * @param color the Color to be used for the background
+     */
+    @Override
+    public void setBackground(Color color) {
+        this.background = color;
+        this.repaint();
+    }
+
     /**
      * Return the current background color used to clear the Pad
      * @return Color object used for the Pad background


### PR DESCRIPTION
1. Added a Pad constructor with (width,height,background color)

2. Tried fixing an issue with [Pad.]setBackground(Color) method On my MacbookAir Senoma 14.3.1 (whether it is specific to this device/OS is unknown) calling the setBackground(Color.BLUE) wouldn't change the color from what it was previously. 

I have `Java 8 & Update 401` and JDK appears to be version 19 in Eclipse, although `java --version` and `javac --version` tell me `20.0.2` (I of course have no clue what any of this means)

(note that setBackground(gray) and setBackground(red,green,blue) methods work as intended.)

Upon inspecting the code, it appears that setBackground(Color) is inherited from a parent (Window) object, and because of how bad my Java Skills are I couldn't figure out anything further than that.

So I decided to Override setBackground(Color) with a pattern from setBackground(red,green,blue) that appears to be working fine.

As you might suspect I didn't test my changes because I don't know how...

<img width="885" alt="A screenshot of the code and the resulting window" src="https://github.com/russomf/doodlepad/assets/86117540/81f1b339-57c7-459c-9320-0dc2939cc27e">
The commented line also creates a blue window as expected.